### PR TITLE
mctp: add SecuredMessages header type support

### DIFF
--- a/src/mctp_traits.rs
+++ b/src/mctp_traits.rs
@@ -178,6 +178,7 @@ pub trait SMBusMCTPRequestResponse {
     fn generate_spdm_msg_packet_bytes(
         &self,
         dest_addr: u8,
+        message_type: MessageType,
         message_header: &Option<&[u8]>,
         message_data: &[u8],
         buf: &mut [u8],
@@ -186,7 +187,7 @@ pub trait SMBusMCTPRequestResponse {
         let base_header = self.generate_transport_header(dest_addr);
 
         let header: MCTPMessageBodyHeader<[u8; 1]> =
-            MCTPMessageBodyHeader::new(false, MessageType::SpdmOverMctp);
+            MCTPMessageBodyHeader::new(false, message_type);
 
         let body = MCTPMessageBody::new(&header, *message_header, message_data, None);
 

--- a/src/smbus.rs
+++ b/src/smbus.rs
@@ -303,6 +303,20 @@ impl<'m> MCTPSMBusContext<'m> {
                 }
                 Ok((MessageType::SpdmOverMctp, &packet[9..(packet_len)]))
             }
+            MessageType::SecuredMessages => {
+                let packet_len = packet.len() - 1;
+                let pec = packet[packet_len];
+
+                if pec != calculated_pec {
+                    #[cfg(test)]
+                    println!("pec {:#x} != calculated_pec {:#x}", pec, calculated_pec);
+                    return Err((
+                        MessageType::SecuredMessages,
+                        DecodeError::ControlMessage(ControlMessageError::InvalidPEC),
+                    ));
+                }
+                Ok((MessageType::SecuredMessages, &packet[9..(packet_len)]))
+            }
             _ => Err((MessageType::Invalid, DecodeError::Unknown)),
         }
     }


### PR DESCRIPTION
This allows us to use libmctp with libraries such as libspdm that use both `SpdmOverMctp` and `SecuredMessages` over the transprot medium.