### PR TITLE
Fix bitfield issue in SMBus header

### DIFF
--- a/src/smbus_proto.rs
+++ b/src/smbus_proto.rs
@@ -28,7 +28,7 @@ bitfield! {
     /// This bit shall be set to 1b. The value enables MCTP to be differentiated from IPMI over SMBus and IPMB (IPMI over I2C) protocols.
     pub source_read_write, set_source_read_write: 24, 24;
     /// For the local SMBus link, the slave address of the source device.
-    pub source_slave_addr, set_source_slave_addr: 30, 25;
+    pub source_slave_addr, set_source_slave_addr: 31, 25;
 }
 
 impl MCTPSMBusHeader<[u8; 4]> {

--- a/src/smbus_response.rs
+++ b/src/smbus_response.rs
@@ -308,7 +308,7 @@ mod tests {
     #[test]
     fn test_generate_smbus_header() {
         const DEST_ID: u8 = 0x23;
-        const SOURCE_ID: u8 = 0x23;
+        const SOURCE_ID: u8 = 0x44;
 
         let ctx = MCTPSMBusContextResponse::new(SOURCE_ID);
 


### PR DESCRIPTION
The SMBus header came up one bit short on the source id field, resulting in addresses over 0x39 being truncated.

* Extended the bitfield to cover all 7 bits of the address field.
* Updated test_generate_smbus_header to exercise that bit.