### PR TITLE
Use a u32 for MCTPTransportHeader storage

### DIFF
--- a/src/base_packet.rs
+++ b/src/base_packet.rs
@@ -44,34 +44,40 @@ impl From<u8> for MessageType {
 
 bitfield! {
     /// The MCTP Transport Header, 4 bytes long.
-    pub struct MCTPTransportHeader(MSB0 [u8]);
+    pub struct MCTPTransportHeader(u32);
     u8;
-    rsvd, _ : 3, 0;
+    rsvd, _ : 31, 28;
     /// Header version
-    pub hdr_version, set_hdr_version: 7, 4;
+    #[inline]
+    pub hdr_version, set_hdr_version: 27, 24;
     /// Destination Endpoint ID
-    pub dest_endpoint_id, set_dest_endpoint_id: 15, 8;
+    #[inline]
+    pub dest_endpoint_id, set_dest_endpoint_id: 23, 16;
     /// Source Endpoint ID
-    pub source_endpoint_id, set_source_endpoint_id: 23, 16;
+    #[inline]
+    pub source_endpoint_id, set_source_endpoint_id: 15, 8;
     /// Start of Message
-    pub som, set_som: 24, 24;
+    #[inline]
+    pub som, set_som: 7, 7;
     /// End of Message
-    pub eom, set_eom: 25, 25;
+    #[inline]
+    pub eom, set_eom: 6, 6;
     /// Packet Sequence Number
-    pub pkt_seq, set_pkt_seq: 27, 26;
+    #[inline]
+    pub pkt_seq, set_pkt_seq: 5, 4;
     /// Tag Owner
-    pub to, set_to: 28, 28;
+    #[inline]
+    pub to, set_to: 3, 3;
     /// Message Tag
-    pub msg_tag, set_msg_tag: 31, 29;
+    pub msg_tag, set_msg_tag: 2, 0;
 }
 
-impl MCTPTransportHeader<[u8; 4]> {
+impl MCTPTransportHeader {
     /// Create a new MCTPTransportHeader.
     ///
     /// `version`: The transport layer specific header version.
     pub fn new(version: u8) -> Self {
-        let buf = [0; 4];
-        let mut tran_header = MCTPTransportHeader(buf);
+        let mut tran_header = MCTPTransportHeader(0);
 
         tran_header.set_hdr_version(version);
 
@@ -83,7 +89,7 @@ impl MCTPTransportHeader<[u8; 4]> {
     /// `buffer`: The existing buffer for the `MCTPTransportHeader`
     /// `version`: The transport layer specific header version.
     pub fn new_from_buf(buf: [u8; 4], version: u8) -> Result<Self, ()> {
-        let header = MCTPTransportHeader(buf);
+        let header = MCTPTransportHeader(u32::from_be_bytes(buf));
 
         if header.rsvd() != 0x00 {
             return Err(());
@@ -94,6 +100,11 @@ impl MCTPTransportHeader<[u8; 4]> {
         }
 
         Ok(header)
+    }
+
+    /// Return the header as bytes.
+    pub fn to_bytes(&self) -> [u8; 4] {
+        self.0.to_be_bytes()
     }
 }
 

--- a/src/mctp_traits.rs
+++ b/src/mctp_traits.rs
@@ -107,8 +107,8 @@ pub trait SMBusMCTPRequestResponse {
     fn set_eid(&self, eid: u8);
 
     /// Generate a transport header
-    fn generate_transport_header(&self, dest_addr: u8) -> MCTPTransportHeader<[u8; 4]> {
-        let mut base_header: MCTPTransportHeader<[u8; 4]> = MCTPTransportHeader::new(HDR_VERSION);
+    fn generate_transport_header(&self, dest_addr: u8) -> MCTPTransportHeader {
+        let mut base_header: MCTPTransportHeader = MCTPTransportHeader::new(HDR_VERSION);
         base_header.set_dest_endpoint_id(dest_addr);
         base_header.set_source_endpoint_id(self.get_address());
         base_header.set_som(true as u8);

--- a/src/smbus.rs
+++ b/src/smbus.rs
@@ -155,7 +155,7 @@ use smbus_pec::pec;
 /// The returned data for SMBus headers
 type SMBusHeaders = (
     MCTPSMBusHeader<[u8; 4]>,
-    MCTPTransportHeader<[u8; 4]>,
+    MCTPTransportHeader,
     MCTPMessageBodyHeader<[u8; 1]>,
 );
 
@@ -355,7 +355,7 @@ impl<'m> MCTPSMBusContext<'m> {
     fn get_mctp_control_packet<'a, 'b>(
         &self,
         _smbus_header: &MCTPSMBusHeader<[u8; 4]>,
-        _base_header: &MCTPTransportHeader<[u8; 4]>,
+        _base_header: &MCTPTransportHeader,
         body_header: &'b MCTPMessageBodyHeader<[u8; 1]>,
         packet: &'a [u8],
         calculated_pec: u8,
@@ -426,7 +426,7 @@ impl<'m> MCTPSMBusContext<'m> {
     fn decode_mctp_control<'a>(
         &self,
         smbus_header: &MCTPSMBusHeader<[u8; 4]>,
-        base_header: &MCTPTransportHeader<[u8; 4]>,
+        base_header: &MCTPTransportHeader,
         body_header: &MCTPMessageBodyHeader<[u8; 1]>,
         packet: &'a [u8],
         calculated_pec: u8,

--- a/src/smbus_proto.rs
+++ b/src/smbus_proto.rs
@@ -56,7 +56,7 @@ impl Default for MCTPSMBusHeader<[u8; 4]> {
 /// The final constructed SMBus packet.
 pub(crate) struct MCTPSMBusPacket<'a, 'b> {
     smbus_header: &'a mut MCTPSMBusHeader<[u8; 4]>,
-    base_header: &'a MCTPTransportHeader<[u8; 4]>,
+    base_header: &'a MCTPTransportHeader,
     data_bytes: &'a MCTPMessageBody<'a, 'b>,
 }
 
@@ -64,7 +64,7 @@ impl<'a, 'b> MCTPSMBusPacket<'a, 'b> {
     /// Create a new SMBUs packet
     pub fn new(
         smbus_header: &'a mut MCTPSMBusHeader<[u8; 4]>,
-        base_header: &'a MCTPTransportHeader<[u8; 4]>,
+        base_header: &'a MCTPTransportHeader,
         data_bytes: &'b MCTPMessageBody,
     ) -> Self {
         let mut packet = Self {
@@ -111,7 +111,7 @@ impl<'a, 'b> MCTPHeader for MCTPSMBusPacket<'a, 'b> {
         buf[0..4].copy_from_slice(&self.smbus_header.0);
         size += 4;
 
-        buf[4..8].copy_from_slice(&self.base_header.0);
+        buf[4..8].copy_from_slice(&self.base_header.to_bytes());
         size += 4;
 
         size += self.data_bytes.to_raw_bytes(&mut buf[size..]);

--- a/src/smbus_request.rs
+++ b/src/smbus_request.rs
@@ -555,7 +555,7 @@ mod tests {
         let ctx = MCTPSMBusContextRequest::new(SOURCE_ID);
 
         let header = ctx.generate_transport_header(DEST_ID);
-        let buf = header.0;
+        let buf = header.to_bytes();
 
         // HDR version and reserved field
         assert_eq!(buf[0], HDR_VERSION);

--- a/src/smbus_response.rs
+++ b/src/smbus_response.rs
@@ -333,7 +333,7 @@ mod tests {
         let ctx = MCTPSMBusContextResponse::new(SOURCE_ID);
 
         let header = ctx.generate_transport_header(DEST_ID);
-        let buf = header.0;
+        let buf = header.to_bytes();
 
         // HDR version and reserved field
         assert_eq!(buf[0], HDR_VERSION);


### PR DESCRIPTION
This saves ~800 bytes of code size from a current project  (cortex M7, opt "s" or "z"), and uses a lot fewer cycles.
I'm pushing this as a draft PR, if you like the approach I could change the other bitfields similarly.

This does change the API a bit, instead of `hdr.0` you use `hdr.to_bytes()`, and the `MCTPTransportHeader` no longer has the type parameter `MCTPTransportHeader<[u8; 4]>`.

This compiles to much more efficient code in the bitfield operations.

The code I'm testing with is fairly simple, setting a few headers similar to:
```rust
        let mut header = MCTPTransportHeader::new(1);
        header.set_dest_endpoint_id(dest);
        header.set_source_endpoint_id(src);
        header.set_pkt_seq(seq);
        if self.first {
            header.set_som(first);
        }
        header.set_msg_tag(tag);
        header.set_to(is_owner);

```